### PR TITLE
fix: only redirect https->http for ssrDebug when proxy is enabled

### DIFF
--- a/background/debugRedirect.ts
+++ b/background/debugRedirect.ts
@@ -1,27 +1,17 @@
-const RULE_ID = 4987235
+export const RULE_ID = 4987235
 
-export const useHttpForSsrDebug = async () => {
-  await chrome.declarativeNetRequest.updateDynamicRules({
-    removeRuleIds: [RULE_ID],
-  })
-  await chrome.declarativeNetRequest.updateDynamicRules({
-    addRules: [
-      {
-        id: RULE_ID,
-        condition: {
-          urlFilter: 'https://*ssrDebug*',
-          resourceTypes: [chrome.declarativeNetRequest.ResourceType.MAIN_FRAME],
-        },
-        action: {
-          type: chrome.declarativeNetRequest.RuleActionType.REDIRECT,
-          redirect: {
-            transform: {
-              scheme: 'http',
-            },
-          },
-        },
+export const ssrDebugRedirectRule: chrome.declarativeNetRequest.Rule = {
+  id: RULE_ID,
+  condition: {
+    urlFilter: 'https://*ssrDebug*',
+    resourceTypes: [chrome.declarativeNetRequest.ResourceType.MAIN_FRAME],
+  },
+  action: {
+    type: chrome.declarativeNetRequest.RuleActionType.REDIRECT,
+    redirect: {
+      transform: {
+        scheme: 'http',
       },
-    ],
-    removeRuleIds: [RULE_ID],
-  })
+    },
+  },
 }

--- a/background/index.ts
+++ b/background/index.ts
@@ -1,5 +1,4 @@
 import { isWix } from '~utils/urlManager'
-import { useHttpForSsrDebug } from './debugRedirect'
 import { initProxy } from './proxy'
 
 // Update the badge of the extension according to whether the current tab is a Wix URL
@@ -14,6 +13,5 @@ chrome.tabs.onActivated.addListener(async ({ tabId }) => {
 })
 
 initProxy()
-useHttpForSsrDebug()
 
 export {}

--- a/background/proxy.ts
+++ b/background/proxy.ts
@@ -1,9 +1,10 @@
 import { Storage } from '@plasmohq/storage'
 import { pacScript } from './pac_script.mjs'
+import { RULE_ID, ssrDebugRedirectRule } from './debugRedirect'
 
 const storage = new Storage()
 
-const handleProxyChange = (proxy) => {
+const handleProxyChange = async (proxy: boolean) => {
   if (proxy) {
     chrome.proxy.settings.set({
       value: {
@@ -14,8 +15,13 @@ const handleProxyChange = (proxy) => {
       },
       scope: 'regular',
     })
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      addRules: [ssrDebugRedirectRule],
+      removeRuleIds: [RULE_ID],
+    })
   } else {
     chrome.proxy.settings.clear({})
+    await chrome.declarativeNetRequest.updateDynamicRules({ removeRuleIds: [RULE_ID] })
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "viewer-devtools",
   "displayName": "Viewer devtools",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A basic Plasmo extension.",
   "author": "nirn",
   "scripts": {


### PR DESCRIPTION
The declarativeNetRequest rule that redirects https://*ssrDebug* -> http:// was registered unconditionally at service worker startup, regardless of whether the local proxy toggle was on or off.

On live Wix sites (proxy off, no local Thunderbolt running) this caused an infinite redirect loop: the extension redirects https->http, the live server responds with a 301 back to https, the extension fires again, and so on. Chrome 121+ no longer breaks DNR-induced redirect cycles, so the page never loads and ssrDebug never activates.

Fix: move the redirect rule lifecycle into handleProxyChange in proxy.ts so it is added when the proxy is enabled (local dev) and removed when disabled (live sites), mirroring how the PAC script is already managed.

- background/debugRedirect.ts: export RULE_ID and ssrDebugRedirectRule as constants; remove the useHttpForSsrDebug async function
- background/proxy.ts: import and add/remove the redirect rule inside handleProxyChange alongside the PAC script settings
- background/index.ts: remove the unconditional useHttpForSsrDebug() call

Made-with: Cursor