### PR TITLE
fix: remove ssrDebug HTTPS→HTTP redirect rule entirely

### DIFF
--- a/background/debugRedirect.ts
+++ b/background/debugRedirect.ts
@@ -1,27 +1,7 @@
-const RULE_ID = 4987235
+export const RULE_ID = 4987235
 
-export const useHttpForSsrDebug = async () => {
+export const cleanupSsrDebugRedirectRule = async () => {
   await chrome.declarativeNetRequest.updateDynamicRules({
-    removeRuleIds: [RULE_ID],
-  })
-  await chrome.declarativeNetRequest.updateDynamicRules({
-    addRules: [
-      {
-        id: RULE_ID,
-        condition: {
-          urlFilter: 'https://*ssrDebug*',
-          resourceTypes: [chrome.declarativeNetRequest.ResourceType.MAIN_FRAME],
-        },
-        action: {
-          type: chrome.declarativeNetRequest.RuleActionType.REDIRECT,
-          redirect: {
-            transform: {
-              scheme: 'http',
-            },
-          },
-        },
-      },
-    ],
     removeRuleIds: [RULE_ID],
   })
 }

--- a/background/debugRedirect.ts
+++ b/background/debugRedirect.ts
@@ -1,6 +1,6 @@
 export const RULE_ID = 4987235
 
-export const cleanupSsrDebugRedirectRule = async () => {
+export const useHttpForSsrDebug = async () => {
   await chrome.declarativeNetRequest.updateDynamicRules({
     removeRuleIds: [RULE_ID],
   })

--- a/background/index.ts
+++ b/background/index.ts
@@ -1,5 +1,5 @@
 import { isWix } from '~utils/urlManager'
-import { useHttpForSsrDebug } from './debugRedirect'
+import { cleanupSsrDebugRedirectRule } from './debugRedirect'
 import { initProxy } from './proxy'
 
 // Update the badge of the extension according to whether the current tab is a Wix URL
@@ -14,6 +14,6 @@ chrome.tabs.onActivated.addListener(async ({ tabId }) => {
 })
 
 initProxy()
-useHttpForSsrDebug()
+cleanupSsrDebugRedirectRule()
 
 export {}

--- a/background/index.ts
+++ b/background/index.ts
@@ -1,5 +1,5 @@
 import { isWix } from '~utils/urlManager'
-import { cleanupSsrDebugRedirectRule } from './debugRedirect'
+import { useHttpForSsrDebug } from './debugRedirect'
 import { initProxy } from './proxy'
 
 // Update the badge of the extension according to whether the current tab is a Wix URL
@@ -14,6 +14,6 @@ chrome.tabs.onActivated.addListener(async ({ tabId }) => {
 })
 
 initProxy()
-cleanupSsrDebugRedirectRule()
+useHttpForSsrDebug()
 
 export {}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "viewer-devtools",
   "displayName": "Viewer devtools",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "A basic Plasmo extension.",
   "author": "nirn",
   "scripts": {


### PR DESCRIPTION
The declarativeNetRequest rule that downgrades https://*ssrDebug* to http:// causes an infinite redirect loop due to Chrome HSTS enforcement on live sites.

The PAC script already handles routing ssrDebug traffic to the local proxy (localhost:4000) without changing the URL scheme, making the redirect rule redundant. Removing it entirely resolves the loop with no loss of functionality.

A cleanup call is still made on startup to remove any previously registered rule from older extension versions.

Made-with: Cursor